### PR TITLE
Add ability to inject internal CA Cert

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -4,8 +4,9 @@ Use the Terraform plugin to apply the infrastructure configuration contained wit
 * `remote` - contains the configuration for the Terraform remote state tracking.
   * `backend` - the Terraform remote state backend to use.
   * `config` - a map of configuration parameters for the remote state backend. Each value is passed as a `-backend-config=<key>=<value>` option.
-  * `ca_cert` - ca cert to add to your environment to allow terraform to use internal/private resources
-* `vars` - a map of variables to pass to the Terraform `plan` and `apply` commands. Each value is passed as a `-var <key>=<value>` option.
+* `vars` - a map of variables to pass to the Terraform `plan` and `apply` commands. Each value is passed as a `-var
+ <key>=<value>` option.
+* `ca_cert` - ca cert to add to your environment to allow terraform to use internal/private resources
 
 The following is a sample Terraform configuration in your .drone.yml file:
 
@@ -15,16 +16,37 @@ deploy:
     plan: false
     remote:
       backend: S3
-      ca_cert: |
-        -----BEGIN CERTIFICATE-----
-        asdfsadf
-        asdfsadf
-        -----END CERTIFICATE-----
       config:
         bucket: my-terraform-config-bucket
         key: tf-states/my-project
         region: us-east-1
-      vars:
-        app_name: my-project
-        app_version: 1.0.0
+    vars:
+      app_name: my-project
+      app_version: 1.0.0
+```
+
+# Advanced Configuration
+
+## CA Certs
+You may want to run terraform against internal resources, like an internal
+OpenStack deployment.  Usually these resources are signed by an internal
+CA Certificate.  You can inject your CA Certificate into the plugin by using
+`ca_certs` key as described above.  Below is an example.
+
+```yaml
+deploy:
+  terraform:
+    dry_run: false
+    remote:
+      backend: swift
+      config:
+        path: drone/terraform
+    vars:
+      app_name: my-project
+      app_version: 1.0.0
+    ca_cert: |
+      -----BEGIN CERTIFICATE-----
+      asdfsadf
+      asdfsadf
+      -----END CERTIFICATE-----
 ```

--- a/DOCS.md
+++ b/DOCS.md
@@ -4,6 +4,7 @@ Use the Terraform plugin to apply the infrastructure configuration contained wit
 * `remote` - contains the configuration for the Terraform remote state tracking.
   * `backend` - the Terraform remote state backend to use.
   * `config` - a map of configuration parameters for the remote state backend. Each value is passed as a `-backend-config=<key>=<value>` option.
+  * `ca_cert` - ca cert to add to your environment to allow terraform to use internal/private resources
 * `vars` - a map of variables to pass to the Terraform `plan` and `apply` commands. Each value is passed as a `-var <key>=<value>` option.
 
 The following is a sample Terraform configuration in your .drone.yml file:
@@ -14,6 +15,11 @@ deploy:
     plan: false
     remote:
       backend: S3
+      ca_cert: |
+        -----BEGIN CERTIFICATE-----
+        asdfsadf
+        asdfsadf
+        -----END CERTIFICATE-----
       config:
         bucket: my-terraform-config-bucket
         key: tf-states/my-project

--- a/main.go
+++ b/main.go
@@ -14,12 +14,12 @@ type terraform struct {
 	Remote remote            `json:"remote"`
 	Plan   bool              `json:"plan"`
 	Vars   map[string]string `json:"vars"`
+	Cacert string            `json:"ca_cert"`
 }
 
 type remote struct {
 	Backend string            `json:"backend"`
 	Config  map[string]string `json:"config"`
-	Cacert  string            `json:"ca_cert"`
 }
 
 func main() {
@@ -33,8 +33,8 @@ func main() {
 
 	var commands []*exec.Cmd
 	remote := vargs.Remote
-	if remote.Cacert != "" {
-		commands = append(commands, installCaCert(remote.Cacert))
+	if vargs.Cacert != "" {
+		commands = append(commands, installCaCert(vargs.Cacert))
 	}
 	if remote.Backend != "" {
 		commands = append(commands, remoteConfigCommand(remote))


### PR DESCRIPTION
I ran into an issue where I could not POST to internal/private Openstack Swift resource for remote config.

This PR adds the ability to inject a CA Cert file so that you can avoid something like the following:

```
$ terraform remote config -backend=swift -backend-config=path=config/path
Post https://openstack.test.com:5000/v2.0/tokens: x509: certificate signed by unknown authority
```

I put it under `remote` in the yaml data structure.  Feel free to update it to a more appropriate key.