### PR TITLE
Sensitive Flag to suppress command trace output

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -37,7 +37,7 @@ CA Certificate.  You can inject your CA Certificate into the plugin by using
 ```yaml
 deploy:
   terraform:
-    dry_run: false
+    plan: false
     remote:
       backend: swift
       config:
@@ -61,7 +61,7 @@ want command is actually being ran.
 ```yaml
 deploy:
   terraform:
-    dry_run: false
+    plan: false
     sensitive: true
     remote:
       backend: S3

--- a/DOCS.md
+++ b/DOCS.md
@@ -7,6 +7,7 @@ Use the Terraform plugin to apply the infrastructure configuration contained wit
 * `vars` - a map of variables to pass to the Terraform `plan` and `apply` commands. Each value is passed as a `-var
  <key>=<value>` option.
 * `ca_cert` - ca cert to add to your environment to allow terraform to use internal/private resources
+* `sensitive` (default: `false`) - Whether or not to suppress terraform commands to stdout.
 
 The following is a sample Terraform configuration in your .drone.yml file:
 
@@ -49,4 +50,26 @@ deploy:
       asdfsadf
       asdfsadf
       -----END CERTIFICATE-----
+```
+
+## Suppress Sensitive Output
+You may be passing sensitive vars to your terraform commands.  If you do not want
+the terraform commands to display in your drone logs then set `sensitive` to `true`.
+The output from the commands themselves will still display, it just won't show
+want command is actually being ran.
+
+```yaml
+deploy:
+  terraform:
+    dry_run: false
+    sensitive: true
+    remote:
+      backend: S3
+      config:
+        bucket: my-terraform-config-bucket
+        key: tf-states/my-project
+        region: us-east-1
+      vars:
+        app_name: my-project
+        app_version: 1.0.0
 ```

--- a/main.go
+++ b/main.go
@@ -11,10 +11,11 @@ import (
 )
 
 type terraform struct {
-	Remote remote            `json:"remote"`
-	Plan   bool              `json:"plan"`
-	Vars   map[string]string `json:"vars"`
-	Cacert string            `json:"ca_cert"`
+	Remote    remote            `json:"remote"`
+	Plan      bool              `json:"plan"`
+	Vars      map[string]string `json:"vars"`
+	Cacert    string            `json:"ca_cert"`
+	Sensitive bool              `json:"sensitive"`
 }
 
 type remote struct {
@@ -49,7 +50,9 @@ func main() {
 		c.Dir = workspace.Path
 		c.Stdout = os.Stdout
 		c.Stderr = os.Stderr
-		trace(c)
+		if !vargs.Sensitive {
+			trace(c)
+		}
 
 		err := c.Run()
 		if err != nil {


### PR DESCRIPTION
I've been passing sensitive info as vars to be used by the terraform commands.  Therefore I'd like the ability to suppress the command trace output in the logs.