### PR TITLE
Use plan instead of dry-run.

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -1,6 +1,6 @@
 Use the Terraform plugin to apply the infrastructure configuration contained within the repository. The following parameters are used to configure this plugin:
 
-* `dry_run` - if true, calculates a plan but does __NOT__ apply it.
+* `plan` - if true, calculates a plan but does __NOT__ apply it.
 * `remote` - contains the configuration for the Terraform remote state tracking.
   * `backend` - the Terraform remote state backend to use.
   * `config` - a map of configuration parameters for the remote state backend. Each value is passed as a `-backend-config=<key>=<value>` option.
@@ -11,7 +11,7 @@ The following is a sample Terraform configuration in your .drone.yml file:
 ```yaml
 deploy:
   terraform:
-    dry_run: false
+    plan: false
     remote:
       backend: S3
       config:

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 
 type terraform struct {
 	Remote remote            `json:"remote"`
-	DryRun bool              `json:"dry_run"`
+	Plan   bool              `json:"plan"`
 	Vars   map[string]string `json:"vars"`
 }
 
@@ -35,7 +35,7 @@ func main() {
 		commands = append(commands, remoteConfigCommand(remote))
 	}
 	commands = append(commands, planCommand(vargs.Vars))
-	if !vargs.DryRun {
+	if !vargs.Plan {
 		commands = append(commands, applyCommand())
 	}
 


### PR DESCRIPTION
Terraform users will be familiar with the `terraform` syntax and terminology, so we should use `plan` instead of `dry-run`.  https://www.terraform.io/docs/commands/plan.html

If there are any other cases where the `terraform` terminology makes sense to use it, we should do that.