### PR TITLE
Manually build terraform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,14 @@
-# Docker image for Drone's terraform deployment plugin
+# Docker image for the Drone Cloud Foundry plugin
 #
-#     CGO_ENABLED=0 go build -a -tags netgo
-#     docker build --rm=true -t plugins/drone-terraform .
+#     cd $GOPATH/src/github.com/drone-plugins/drone-terraform
+#     make deps build docker
 
-FROM gliderlabs/alpine:3.2
-RUN apk-install ca-certificates
-
-ENV TERRAFORM_VERSION 0.6.14
+FROM alpine:3.2
 
 RUN apk update && \
-    wget -q "https://circle-artifacts.com/gh/andyshinn/alpine-pkg-glibc/6/artifacts/0/home/ubuntu/alpine-pkg-glibc/packages/x86_64/glibc-2.21-r2.apk" && \
-    apk add --allow-untrusted glibc-2.21-r2.apk && \
-    wget -q -O terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \
-    unzip terraform.zip -d /bin && \
-    rm -rf /var/cache/apk/* glibc-2.21-r2.apk terraform.zip
+  apk add ca-certificates && \
+  rm -rf /var/cache/apk/*
 
+ADD terraform /bin/
 ADD drone-terraform /bin/
 ENTRYPOINT ["/bin/drone-terraform"]

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ clean:
 	go clean -i ./...
 
 deps:
+	go get -d github.com/hashicorp/terraform
 	go get -t ./...
 
 fmt:
@@ -25,10 +26,12 @@ test:
 	@for PKG in $(PACKAGES); do go test -cover -coverprofile $$GOPATH/src/$$PKG/coverage.out $$PKG || exit 1; done;
 
 docker:
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o terraform github.com/hashicorp/terraform
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags '-s -w $(LDFLAGS)'
 	docker build --rm -t $(IMAGE) .
 
 $(EXECUTABLE): $(wildcard *.go)
+	go build -o terraform github.com/hashicorp/terraform
 	go build -ldflags '-s -w $(LDFLAGS)'
 
 build: $(EXECUTABLE)


### PR DESCRIPTION
To avoid the installation of packages that are not part of the official
Alpine distribution I have integrated a similar bahavior as we already
have for the drone-cloudfoundry plugin. I'm downloading the terraform
sources and I'm building the binary together with drone-terraform.

Signed-off-by: Thomas Boerger <tboerger@suse.de>