### PR TITLE
not using dir as base dir if it's empty

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,6 +66,12 @@ func main() {
 	for _, c := range commands {
 		c.Env = os.Environ()
 		c.Dir = workspace.Path
+		if c.Dir == "" {
+			wd, err := os.Getwd()
+			if err == nil {
+				c.Dir = wd
+			}
+		}
 		if vargs.RootDir != "" {
 			c.Dir = c.Dir + "/" + vargs.RootDir
 		}


### PR DESCRIPTION
Proposed check to see if the path is empty and use the working dir if it is. This came out of a discussion I had with @bradrydzewski around how to call terraform in the `build` step of a drone build. The suggested way (which should be easier in 0.5) was to use the drone-terraform image and create the plugin config in json, something like

`/bin/drone-terraform -- '{"vargs":{"plan":true...}'`

When calling this way, `path` is empty. 