### PR TITLE
Add terraform '-parallelism=' option

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -8,8 +8,9 @@ Use the Terraform plugin to apply the infrastructure configuration contained wit
  <key>=<value>` option.
 * `ca_cert` - ca cert to add to your environment to allow terraform to use internal/private resources
 * `sensitive` (default: `false`) - Whether or not to suppress terraform commands to stdout.
-* `role_arn_to_assume` - A role to assume before running the terraform commands
+* `role_arn_to_assume` - A role to assume before running the terraform commands.
 * `root_dir` - The root directory where the terraform files live. When unset, the top level directory will be assumed.
+* `parallelism` - The number of concurrent operations as Terraform walks its graph.
 
 The following is a sample Terraform configuration in your .drone.yml file:
 
@@ -112,4 +113,24 @@ deploy:
       app_name: my-project
       app_version: 1.0.0
     root_dir: some/path/here
+```
+
+## Parallelism
+You may want to limit the number of concurrent operations as Terraform walks its graph.
+If you want to change Terraform's default parallelism (currently equal to 10) then set the `parallelism` parameter.
+
+```yaml
+deploy:
+  terraform:
+    plan: false
+    remote:
+      backend: S3
+      config:
+        bucket: my-terraform-config-bucket
+        key: tf-states/my-project
+        region: us-east-1
+    vars:
+      app_name: my-project
+      app_version: 1.0.0
+    parallelism: 2
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@
 FROM gliderlabs/alpine:3.2
 RUN apk-install ca-certificates git
 
-ENV TERRAFORM_VERSION 0.6.14
+ENV TERRAFORM_VERSION 0.6.16
 
 RUN apk update && \
-    wget -q "https://circle-artifacts.com/gh/andyshinn/alpine-pkg-glibc/6/artifacts/0/home/ubuntu/alpine-pkg-glibc/packages/x86_64/glibc-2.21-r2.apk" && \
+    wget -q "https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.21-r2/glibc-2.21-r2.apk" && \
     apk add --allow-untrusted glibc-2.21-r2.apk && \
     wget -q -O terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \
     unzip terraform.zip -d /bin && \


### PR DESCRIPTION
* Update terraform version to 0.6.16
* Add `parallelism` parameter to limit the number of concurrent operations as Terraform walks its graph
* Download **glibc-2.21-r2.apk** from `github.com/sgerrand/alpine-pkg-glibc` as `circle-artifacts.com/gh/andyshinn/alpine-pkg-glibc` is not available

Fixes #21